### PR TITLE
fix a bug.

### DIFF
--- a/dreamer-datasets/dd_scripts/converters/nuscenes_converter.py
+++ b/dreamer-datasets/dd_scripts/converters/nuscenes_converter.py
@@ -1072,7 +1072,8 @@ def view_points_depth(points, view, normalize):
 def main():
     opt = Options().parse()
     nusc_version = opt.nusc_version
-    data_dir = os.path.join(opt.data_root, nusc_version)
+    # data_dir = os.path.join(opt.data_root, nusc_version)
+    data_dir = opt.data_root
     save_root = opt.save_root
     save_path = os.path.join(save_root, nusc_version)
     nusc_convertor = NuScenesConverter(data_dir=data_dir, version=nusc_version, save_path=save_path, save_version='v0.0.1')


### PR DESCRIPTION
The `data_dir` in `nuscenes_converter.py` seems to have repeatedly joined `nusc_version`.  
This causes the following error in the `Nuscenes` class:  
`AssertionError: Database version not found: nuscenes/v1.0-mini/v1.0-mini`
I've fixed this bug. Please check the update. :D